### PR TITLE
Ensure your security group blocks unwanted inbound traffic

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -89,10 +89,12 @@ resource "aws_security_group" "apsouth1-ec2-securitygroup2" {
   ingress {
     from_port   = 443
     to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    protocol    = "tcp"            
+    # [Shisho]: remove `0.0.0.0/0` from the following line and add appropriate IP ranges
+    cidr_blocks = [ "0.0.0.0/0" ]
   }
 }
+
 
 #######################################################
 


### PR DESCRIPTION
This pull request improves our infrastructure by fixing a security issue found by [Shisho Cloud](https://shisho.dev).

## Description from Shisho Cloud

Your security group allows ingress traffic from all IPs, exposing resources in the VPC to unwanted attacks. If it is intentional, you can help your colleagues by leaving a comment that says it is intentionally done so.

