### PR TITLE
Ensure S3 bucket versoning is enabled

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,6 +1,6 @@
 # ALLUSERS have Full Control
 resource "aws_s3_bucket" "iac-apsouth1-s3-FullControl" {
- bucket = "iac-apsouth1-s3-FullControl"
+  bucket = "iac-apsouth1-s3-FullControl"
  force_destroy=true
  grant {
     type = "Group"
@@ -10,7 +10,11 @@ resource "aws_s3_bucket" "iac-apsouth1-s3-FullControl" {
  tags={
    Name = "iac-apsouth1-s3-permissions-FullControl"
  }
+  versioning {
+    enabled = true
+  }
 }
+
 
 # ALLUSERS have read access
 resource "aws_s3_bucket" "iac-apsouth1-s3-FullRead" {


### PR DESCRIPTION
This pull request improves our infrastructure by fixing a security issue found by [Shisho Cloud](https://shisho.dev).

## Description from Shisho Cloud

You can enable versioning of your S3 bucket to preserve, retrieve, and restore old versions of every object. It may help you handle availability and integrity issues.

